### PR TITLE
Classes that exist but no longer extend from Scheduler prevent any others from getting scheduled

### DIFF
--- a/lib/scheduler/manager.rb
+++ b/lib/scheduler/manager.rb
@@ -211,6 +211,14 @@ module Scheduler
           redis.zrem Manager.queue_key(hostname), key
           return
         end
+
+        unless klass.respond_to?(:daily) &&
+               klass.respond_to?(:every)
+          # job klass exists but no longer extends from the base
+          redis.zrem Manager.queue_key(hostname), key
+          return
+        end
+
         info = schedule_info(klass)
         info.prev_run = Time.now.to_i
         info.prev_result = "QUEUED"

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -51,6 +51,9 @@ describe Scheduler::Manager do
         self.class.runs += 1
       end
     end
+
+    class InvalidJob
+    end
   end
 
   let(:manager) { Scheduler::Manager.new($redis) }
@@ -110,6 +113,12 @@ describe Scheduler::Manager do
 
     it 'should nuke missing jobs' do
       $redis.zadd Scheduler::Manager.queue_key, Time.now.to_i - 1000, "BLABLA"
+      manager.tick
+      expect($redis.zcard(Scheduler::Manager.queue_key)).to eq(0)
+    end
+
+    it 'should nuke invalid jobs' do
+      $redis.zadd Scheduler::Manager.queue_key, Time.now.to_i - 1000, "Testing::InvalidJob"
       manager.tick
       expect($redis.zcard(Scheduler::Manager.queue_key)).to eq(0)
     end


### PR DESCRIPTION
It fails on this job and then never gets to the next job. This ensures that it gets removed from the scheduler.
