### PR TITLE
Removed Jobs::HandledExceptionWrapper

### DIFF
--- a/lib/scheduler/manager.rb
+++ b/lib/scheduler/manager.rb
@@ -61,9 +61,6 @@ module Scheduler
           info.prev_result = "RUNNING"
           @mutex.synchronize { info.write! }
           klass.new.perform
-        # rescue Jobs::HandledExceptionWrapper
-        #   # Discourse.handle_exception was already called, and we don't have any extra info to give
-        #   failed = true
         rescue => e
           Scheduler.handle_job_exception(e, {message: "Running a scheduled job", job: klass})
           failed = true

--- a/lib/scheduler/manager.rb
+++ b/lib/scheduler/manager.rb
@@ -61,9 +61,9 @@ module Scheduler
           info.prev_result = "RUNNING"
           @mutex.synchronize { info.write! }
           klass.new.perform
-        rescue Jobs::HandledExceptionWrapper
-          # Discourse.handle_exception was already called, and we don't have any extra info to give
-          failed = true
+        # rescue Jobs::HandledExceptionWrapper
+        #   # Discourse.handle_exception was already called, and we don't have any extra info to give
+        #   failed = true
         rescue => e
           Scheduler.handle_job_exception(e, {message: "Running a scheduled job", job: klass})
           failed = true


### PR DESCRIPTION
This catch was too specific to Discourse (meaning we don't have this class.) It was removed and we can revisit if we want to merge back in.
