### PR TITLE
Rails 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ rvm:
 services:
   - redis-server
 
-before_install: gem install bundler -v 1.17.3
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v 1.17.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.3.8
+  - 2.5.5
 
 services:
   - redis-server
 
-before_install: gem install bundler -v 1.10.5
+before_install: gem install bundler -v 1.17.3

--- a/lib/scheduler/version.rb
+++ b/lib/scheduler/version.rb
@@ -1,3 +1,3 @@
 module Scheduler
-  VERSION = "0.1.3"
+  VERSION = "0.1.5"
 end

--- a/scheduler.gemspec
+++ b/scheduler.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "coveralls"
 
-  spec.add_dependency "rails", "< 5.0"
+  spec.add_dependency "rails", ">= 4.2", "< 6.0"
   spec.add_dependency "redis"
   spec.add_dependency "sidekiq"
-  spec.add_dependency "redlock", "0.1.8"
+  spec.add_dependency "redlock", "~> 1.0.0"
 end

--- a/scheduler.gemspec
+++ b/scheduler.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 1.17.3"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "sqlite3"


### PR DESCRIPTION
Explicitly give the OK for all versions of Rails between >=4.2 and <6.0. Also bump up redlock to 1.0.0.

Tested, no issues found.